### PR TITLE
add kernel visa to android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1287,6 +1287,11 @@
       "version": "8\\.+"
     },
     {
+      "group": "com\\.mercadopago\\.mpos\\.android\\.mpos\\.ttpkernel",
+      "name": "visa-kernel",
+      "version": "22\\.0\\.0"
+    },
+    {
       "group": "com\\.mercadopago\\.android\\.isp\\.point\\.mpoc",
       "name": "mpoc",
       "version": "0\\.+"


### PR DESCRIPTION
# Descripción
A new SDK from Visa was added to be able to read cards using NFC hardware on android
# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [X] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store